### PR TITLE
lcov spec says the SF path should be an absolute path.

### DIFF
--- a/tasks/karma_sonar.js
+++ b/tasks/karma_sonar.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         function getUpdatedLcovFileContent(source) {
             if (grunt.file.exists(source.coverageReport)) {
                 var content = grunt.file.read(source.coverageReport);
-                return content.replace(/SF:\./ig, 'SF:./' + source.prefix);
+                return content.replace(/SF:\./ig, 'SF:' + source.prefix);
             } else {
                 grunt.log.error(source.coverageReport + " does not exist.");
                 return null;


### PR DESCRIPTION
http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php

However istanbul is generating a releative path.
gotwarlost/istanbul#104

refix can help fix this issue by prefixing with an absolute path.
prefix currently prepends ./ to the prefix which makes it a releative path and breaks it on windows.

fixes  mdasberg/grunt-karma-sonar#1
