### PR TITLE
robustness / check if a matching spec has been found to avoid replace failure

### DIFF
--- a/tasks/jasmineJunit.js
+++ b/tasks/jasmineJunit.js
@@ -89,15 +89,19 @@
                                             return test === name || xmlEntities.encode(test) === name;
                                         });
                                     }), 'name');
-                                    var matchingSpec = matchingSpecs[0];
-                                    if (matchingSpecs.length > 1) {
-                                        var m = _.find(specs, function (spec) {
-                                            return spec.name === matchingSpec;
-                                        });
-                                        m.tests = _.without(m.tests, name);
+                                    if (matchingSpecs.length === 0) {
+                                        grunt.log.warn('No spec filename found for test [' + name + ']');
+                                    } else {
+                                        var matchingSpec = matchingSpecs[0];
+                                        if (matchingSpecs.length > 1) {
+                                            var m = _.find(specs, function (spec) {
+                                                return spec.name === matchingSpec;
+                                            });
+                                            m.tests = _.without(m.tests, name);
+                                        }
+                                        testcase.attr.name = name;
+                                        testcase.attr.classname = matchingSpec.replace(/\./g, '_');
                                     }
-                                    testcase.attr.name = name;
-                                    testcase.attr.classname = matchingSpec.replace(/\./g, '_');
                                 }
                             });
                         }


### PR DESCRIPTION
Checking if a matching spec has been found prior to adding test to xml results.
This should prevent the 'replace' method to fail on an undefined matchingSpec with the following error:

    Warning: Cannot call method 'replace' of undefined Use --force to continue.

Here's a sample case to reproduce.
Our spec defines test cases dynamically as follows:

```javascript
(function testAPIRegistration(resources) {
      angular.forEach(resources, function(resource) {
        it('should register resource <' + resource + '>', inject(function($injector) {
          expect($injector.get(resource)).toBeDefined();
        }));
      });
    })([
      'userAPI',
      'caseAPI'
    ]);
```

Then in the original XML result file we have:
```xml
<testcase name="should register resource &lt;userAPI&gt;" time="0.002" classname="PhantomJS 1.9.8 (Linux 0.0.0).Resources API"/>                                                                                                                                           
<testcase name="should register resource &lt;caseAPI&gt;" time="0.002" classname="PhantomJS 1.9.8 (Linux 0.0.0).Resources API"/>
```

And grunt-karma-sonar fails to find the matching spec based on the tests name "should register resource &lt;userAPI&gt;".

Hence I think we should not fail the build but warn that we could not find any matching spec file name for these tests.
