### PR TITLE
Add debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ runnerProperties: {
 }
 ```
 
+#### options.debug
+Type: `Boolean`
+Default: 'false'
+
+If true sonar-runner debug logging will be turned on. 
+
 #### project
 Type: `Object`,
 Mandatory: true

--- a/tasks/sonar.js
+++ b/tasks/sonar.js
@@ -108,6 +108,13 @@
             return args;
         }
 
+        function logArguments(message, opts) {
+            grunt.log.writeln(message, opts.args);
+            _.each(opts.args, function (arg) {
+                grunt.log.writeln(arg);
+            });
+        }
+
         return {
             run: function (configuration) {
                 var data = configuration.data;
@@ -184,6 +191,7 @@
                             });
                             callback(null, 200);
                         },
+
                         // #6
                         publish: function (callback) {
                             var opts = {
@@ -208,7 +216,15 @@
                                 });
                             }
 
+                            // enable debug
+                            if (sonarOptions.debug) {
+                                opts.args.push('-X');
+                            }
+
                             if (!sonarOptions.dryRun) {
+                                if (sonarOptions.debug) {
+                                    this.logArguments('Sonar will run with the following sonar properties:', opts);
+                                }
                                 grunt.util.spawn(opts, function (error, result, code) {
                                     if (code !== 0) {
                                         return grunt.warn('The following error occured while trying to upload to sonar: ' + error);
@@ -219,10 +235,7 @@
                                 });
                             } else {
                                 grunt.log.subhead('Dry-run');
-                                grunt.log.writeln('Sonar would have been triggered with the following sonar properties:', opts.args);
-                                _.each(opts.args, function (arg) {
-                                    grunt.log.writeln(arg);
-                                });
+                                this.logArguments('Sonar would have been triggered with the following sonar properties:', opts);
                                 callback(null, 200);
                             }
 

--- a/tasks/sonar.js
+++ b/tasks/sonar.js
@@ -223,7 +223,7 @@
 
                             if (!sonarOptions.dryRun) {
                                 if (sonarOptions.debug) {
-                                    this.logArguments('Sonar will run with the following sonar properties:', opts);
+                                    logArguments('Sonar will run with the following sonar properties:', opts);
                                 }
                                 grunt.util.spawn(opts, function (error, result, code) {
                                     if (code !== 0) {
@@ -235,10 +235,9 @@
                                 });
                             } else {
                                 grunt.log.subhead('Dry-run');
-                                this.logArguments('Sonar would have been triggered with the following sonar properties:', opts);
+                                logArguments('Sonar would have been triggered with the following sonar properties:', opts);
                                 callback(null, 200);
                             }
-
                         }
                     },
                     function (err) {


### PR DESCRIPTION
Adds an option "debug" to the configuration. If set to true, sonar-runner debug output will be shown. Also the arguments with which sonar-runner is started will be shown.